### PR TITLE
#251 Add bottom padding for detail page descriptions

### DIFF
--- a/src/components/product/detail/ProductInfo.tsx
+++ b/src/components/product/detail/ProductInfo.tsx
@@ -63,7 +63,7 @@ export function ProductInfo({ product }: { readonly product: ProductDetail }) {
                             </Button>
                         </div>
                     </div>
-                    <p className="mask-linear-[to_bottom,transparent_0%,black_10%,black_90%,transparent_100%] pt-2 pb-2 text-base text-muted-foreground overflow-y-auto max-h-[250px] md:max-h-[130px] lg:max-h-[200px] w-full pr-3">
+                    <p className="mask-linear-[to_bottom,transparent_0%,black_10%,black_90%,transparent_100%] py-2 text-base text-muted-foreground overflow-y-auto max-h-[250px] md:max-h-[130px] lg:max-h-[200px] w-full pr-3">
                         {product.description ?? t("product.noDescription")}
                     </p>
 


### PR DESCRIPTION
fixes #251 

<img width="1261" height="463" alt="image" src="https://github.com/user-attachments/assets/043858bf-d983-4242-8b69-d31eb71b09ab" />

<img width="1262" height="440" alt="image" src="https://github.com/user-attachments/assets/dc6a472b-e361-4deb-a759-b942d2f1e66c" />
